### PR TITLE
fix/ User was not automatically being signed in after registration completed

### DIFF
--- a/src/components/RegisterForm/RegisterForm.tsx
+++ b/src/components/RegisterForm/RegisterForm.tsx
@@ -7,7 +7,7 @@ import { useHistory } from 'react-router-dom';
 
 import './RegisterForm.css';
 import RegisterFormData from '../../interfaces/RegisterFormData';
-import { registerUser } from '../../lib/auth';
+import { registerUser, logIn } from '../../lib/auth';
 import { useUserContext } from '../../contexts/UserContext';
 
 export default function RegisterForm(): JSX.Element {
@@ -27,10 +27,12 @@ export default function RegisterForm(): JSX.Element {
             formData.entries()
             // eslint-disable-next-line
         ) as any;
+        const { email, password } = formValue;
         registerUser(formValue)
-            .then(({ data }) => {
+            .then(async ({ data }) => {
                 // eslint-disable-next-line
                 console.log(`User successfully created!`, data);
+                await logIn(email, password);
                 history.push('/');
             })
             // eslint-disable-next-line


### PR DESCRIPTION
I assumed that auth would automatically sign in a user after you create an account, but that is not the case. I noticed that after I successfully registered a user, on the firebase authentication, the field for "signed in" was not being populated, indicating that signing in does not take place after registration. So to fix this, we just manually sign the user in after registration is complete.