### PR TITLE
KSP-120: added Reset and Clear buttons and functionality

### DIFF
--- a/src/pages/CalendarPage/CalendarPage.tsx
+++ b/src/pages/CalendarPage/CalendarPage.tsx
@@ -47,6 +47,20 @@ function UpdateAvailabilityModal({
         setUserAvailabilityData(newUserAvailabilityData);
     };
 
+    const onClickClearHandle = (
+        e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    ) => {
+        setUserAvailabilityData(
+            createZeroStateArray(LABELS.yLabels.length, LABELS.xLabels.length)
+        );
+    };
+
+    const onClickResetHandle = (
+        e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    ) => {
+        setUserAvailabilityData(mapData);
+    };
+
     const onClickCancelHandle = (
         e: React.MouseEvent<HTMLButtonElement, MouseEvent>
     ) => {
@@ -84,6 +98,8 @@ function UpdateAvailabilityModal({
                 />
             </Modal.Body>
             <Modal.Footer>
+                <Button onClick={(e) => onClickResetHandle(e)}>Reset</Button>
+                <Button onClick={(e) => onClickClearHandle(e)}>Clear</Button>
                 <Button
                     variant="secondary"
                     onClick={(e) => onClickCancelHandle(e)}


### PR DESCRIPTION
Added two buttons to Calendar Page “Add Availability” modal.

Reset button reverts any changes made and not saved, showing the user the availability map they started with.

Clear button removes all selected availability tiles from the view.

Neither button persists anything to the database, and is purely for greater usability. Changes can be saved using the Update button.