### PR TITLE
Ksp 120 calendar page add availability buttons

### DIFF
--- a/src/pages/CalendarPage/CalendarPage.tsx
+++ b/src/pages/CalendarPage/CalendarPage.tsx
@@ -47,17 +47,13 @@ function UpdateAvailabilityModal({
         setUserAvailabilityData(newUserAvailabilityData);
     };
 
-    const onClickClearHandle = (
-        e: React.MouseEvent<HTMLButtonElement, MouseEvent>
-    ) => {
+    const onClickClearHandle = () => {
         setUserAvailabilityData(
             createZeroStateArray(LABELS.yLabels.length, LABELS.xLabels.length)
         );
     };
 
-    const onClickResetHandle = (
-        e: React.MouseEvent<HTMLButtonElement, MouseEvent>
-    ) => {
+    const onClickResetHandle = () => {
         setUserAvailabilityData(mapData);
     };
 
@@ -98,8 +94,8 @@ function UpdateAvailabilityModal({
                 />
             </Modal.Body>
             <Modal.Footer>
-                <Button onClick={(e) => onClickResetHandle(e)}>Reset</Button>
-                <Button onClick={(e) => onClickClearHandle(e)}>Clear</Button>
+                <Button onClick={() => onClickResetHandle()}>Reset</Button>
+                <Button onClick={() => onClickClearHandle()}>Clear</Button>
                 <Button
                     variant="secondary"
                     onClick={(e) => onClickCancelHandle(e)}

--- a/src/pages/CalendarPage/CalendarPage.tsx
+++ b/src/pages/CalendarPage/CalendarPage.tsx
@@ -92,15 +92,12 @@ function UpdateAvailabilityModal({
                 />
             </Modal.Body>
             <Modal.Footer>
-                <Button onClick={() => onClickResetHandle()}>Reset</Button>
-                <Button onClick={() => onClickClearHandle()}>Clear</Button>
-                <Button
-                    variant="secondary"
-                    onClick={(e) => onClickCancelHandle(e)}
-                >
+                <Button onClick={onClickResetHandle}>Reset</Button>
+                <Button onClick={onClickClearHandle}>Clear</Button>
+                <Button variant="secondary" onClick={onClickCancelHandle}>
                     Cancel
                 </Button>
-                <Button onClick={(e) => onClickUpdateHandle(e)}>Update</Button>
+                <Button onClick={onClickUpdateHandle}>Update</Button>
             </Modal.Footer>
         </Modal>
     );

--- a/src/pages/CalendarPage/CalendarPage.tsx
+++ b/src/pages/CalendarPage/CalendarPage.tsx
@@ -31,7 +31,7 @@ function UpdateAvailabilityModal({
     show,
     onHide,
 }: UpdateAvailabilityModalProps): JSX.Element {
-    const { yData, xData, mapData } = heatMapData;
+    const { yData, xData, mapData, zeroState } = heatMapData;
 
     const [userAvailabilityData, setUserAvailabilityData] =
         React.useState<number[][]>(mapData);
@@ -48,9 +48,7 @@ function UpdateAvailabilityModal({
     };
 
     const onClickClearHandle = () => {
-        setUserAvailabilityData(
-            createZeroStateArray(LABELS.yLabels.length, LABELS.xLabels.length)
-        );
+        setUserAvailabilityData(zeroState);
     };
 
     const onClickResetHandle = () => {
@@ -120,22 +118,23 @@ export default function CalendarPage(): JSX.Element {
             return getDocSnapshot$(`/users/${user.uid}`, {
                 next: (snapshot) => {
                     const newUserData = snapshot.data() as UserData;
+                    const zeroState = createZeroStateArray(
+                        LABELS.yLabels.length,
+                        LABELS.xLabels.length
+                    );
                     setUserData(newUserData);
                     setHeatMapData({
                         yData: LABELS.yLabels,
                         xData: LABELS.xLabels,
                         mapData:
                             Object.values(newUserData.availability).length === 0
-                                ? createZeroStateArray(
-                                      LABELS.yLabels.length,
-                                      LABELS.xLabels.length
-                                  )
+                                ? zeroState
                                 : createCalendarAvailabilityDataArray(
                                       LABELS.yLabels,
                                       LABELS.xLabels,
                                       newUserData.availability
                                   ),
-                        zeroState: [[]],
+                        zeroState,
                     });
                 },
             });

--- a/src/pages/CalendarPage/CalendarPage.tsx
+++ b/src/pages/CalendarPage/CalendarPage.tsx
@@ -47,6 +47,20 @@ function UpdateAvailabilityModal({
         setUserAvailabilityData(newUserAvailabilityData);
     };
 
+    const onClickClearHandle = (
+        e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    ) => {
+        setUserAvailabilityData(
+            createZeroStateArray(LABELS.yLabels.length, LABELS.xLabels.length)
+        );
+    };
+
+    const onClickResetHandle = (
+        e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    ) => {
+        setUserAvailabilityData(mapData);
+    };
+
     const onClickCancelHandle = (
         e: React.MouseEvent<HTMLButtonElement, MouseEvent>
     ) => {
@@ -84,6 +98,8 @@ function UpdateAvailabilityModal({
                 />
             </Modal.Body>
             <Modal.Footer>
+                <Button onClick={(e) => onClickResetHandle(e)}>Reset</Button>
+                <Button onClick={(e) => onClickClearHandle(e)}>Clear</Button>
                 <Button
                     variant="secondary"
                     onClick={(e) => onClickCancelHandle(e)}


### PR DESCRIPTION
Add two buttons to Calendar Page “Add Availability” modal.

Reset button reverts any changes made and not saved, showing the user the availability map they started with.

Clear button removes all selected availability tiles from the view.

Neither button persists anything to the database, and is purely for greater usability. Changes can be saved using the Update button.